### PR TITLE
change setVisible(false) into dispose for ProgressFrame

### DIFF
--- a/src/main/java/jive3/ProgressFrame.java
+++ b/src/main/java/jive3/ProgressFrame.java
@@ -53,6 +53,7 @@ public class ProgressFrame extends JFrame {
   }
 
   private void forceRepaint() {
+    setVisible(true);
     Graphics g = getGraphics();
     paint(g);
     g.dispose();

--- a/src/main/java/jive3/ProgressFrame.java
+++ b/src/main/java/jive3/ProgressFrame.java
@@ -27,7 +27,7 @@ public class ProgressFrame extends JFrame {
   }
 
   static public void hideProgress() {
-    if(prgFrame!=null) prgFrame.setVisible(false);
+    if(prgFrame!=null) prgFrame.dispose();
   }
 
   // -------------------------------------------------------


### PR DESCRIPTION
Hi,

We have noticed that when we modify more device properties at one time in jive "Updating properties" Frame is not closed properly. One can fix it bu changing `setVisible(false)` into `dispose()` for `ProgressFrame` , i.e.  [issue47](https://github.com/tango-controls/jive/issues/47).

Best regards,
Jan